### PR TITLE
Download wavefields from LMU, if gdrive token is not available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,5 +94,5 @@ after_success:
 cache:
   directories:
     - $HOME/local
-    - $HOME/wavefield
     - $HOME/miniconda
+      #- $HOME/wavefield

--- a/TRAVIS/get_wavefields.sh
+++ b/TRAVIS/get_wavefields.sh
@@ -1,22 +1,38 @@
 #!/bin/bash
-ls -l wavefield/bwd_merged/
 if [ -f "wavefield/bwd_merged/merged_instaseis_db.nc4" ]; then
   echo "Wavefields available from cache"
 else
-  echo "Wavefields need to be downloaded from Google Drive"
+  echo "Wavefields need to be downloaded"
 
-  # 1. Download gdrive client
-  wget "https://docs.google.com/uc?id=0B3X9GlR6EmbnQ0FtZmJJUXEyRTA&export=download" -O gdrive
-  chmod +x ./gdrive
+  # Check, whether encrypted token for Google Drive account is available
+  # Local gdrive installation needs to be activated with it, but since it
+  # offers read/write access, it should not be shared with other accounts 
+  # than github/seismology.
+  # Download from gdrive is much faster (50-100MB/s) than from LMU (<10 MB/s),
+  # but pull requests from other github accounts than seismology will not have
+  # access to it. 
+  if [ $encrypted_50ebf69bd92e_key == "" ]; then
 
-  # 2. Decrypt gdrive token
-  mkdir $HOME/.gdrive
-  openssl aes-256-cbc -K $encrypted_50ebf69bd92e_key -iv $encrypted_50ebf69bd92e_iv -in TRAVIS/token_v2.json.enc -out $HOME/.gdrive/token_v2.json -d
-  
-  # 3. Download wavefield archive with gdrive client
-  ./gdrive download 0B2O7p0iBm8A9SWk1WjJZUDR5dVU
+    echo "Downloading from LMU"
+    # 1. Download archive from LMU server
+    wget https://www.geophysik.uni-muenchen.de/~staehler/kerner_wavefields.tar.bz2
 
-  # 4. Untar wavefield files
-  tar -xvf kerner_wavefields.tar.bz2
+    # 2. Unpack archive
+    tar -xvf kerner_wavefields.tar.bz2
 
+  else
+
+    echo "Downloading from Google Drive"
+    # 1. Download gdrive client
+    wget "https://docs.google.com/uc?id=0B3X9GlR6EmbnQ0FtZmJJUXEyRTA&export=download" -O gdrive
+    chmod +x ./gdrive
+
+    # 2. Decrypt gdrive token
+    mkdir $HOME/.gdrive
+    openssl aes-256-cbc -K $encrypted_50ebf69bd92e_key -iv $encrypted_50ebf69bd92e_iv -in TRAVIS/token_v2.json.enc -out $HOME/.gdrive/token_v2.json -d
+    
+    # 3. Download wavefield folder with gdrive client
+    ./gdrive download 0BwU9d5SH6pPQNGpkcW9hWHlpYTA --recursive
+
+  fi
 fi


### PR DESCRIPTION
 - for forks and pull requests from outside github/seismology
 - Download unpacked files from gdrive. Faster than working with packed
   archive
 - Do not try to save wavefields dir in travis cache, does not work
   anyway