### PR TITLE
Bug fixes

### DIFF
--- a/src/kernel.f90
+++ b/src/kernel.f90
@@ -529,18 +529,18 @@ function calc_basekernel(ibasekernel, strain_type_fwd, strain_type_bwd, &
   case(1) ! k_lambda
      select case(trim(strain_type_fwd))
      case('straintensor_trace')
-        conv_field_fd = sum(fw_field_fd * bw_field_fd, 2)
+        conv_field_fd = - sum(fw_field_fd * bw_field_fd, 2)
 
      case('straintensor_full')
         select case(trim(strain_type_bwd))
         case('straintensor_trace') !This receiver has only trace base vectors
-           conv_field_fd = (fw_field_fd(:,1,:) +    &
+           conv_field_fd = - (fw_field_fd(:,1,:) +    &
                             fw_field_fd(:,2,:) +    &
                             fw_field_fd(:,3,:)  ) * &
                             bw_field_fd(:,1,:) ! This row contains the trace
         case('straintensor_full')
            ! Only convolve trace of fw and bw fields
-           conv_field_fd = (fw_field_fd(:,1,:) +    &
+           conv_field_fd =  - (fw_field_fd(:,1,:) +    &
                             fw_field_fd(:,2,:) +    &
                             fw_field_fd(:,3,:)  ) * &
                            (bw_field_fd(:,1,:) +    &
@@ -549,7 +549,7 @@ function calc_basekernel(ibasekernel, strain_type_fwd, strain_type_bwd, &
         end select
      end select
   case(2) ! k_mu
-     conv_field_fd = sum(fw_field_fd * bw_field_fd, 2) * 2.d0
+     conv_field_fd = - sum(fw_field_fd * bw_field_fd, 2) * 2.d0
   case(3) ! k_rho
      print*,"ERROR: Density kernels not yet implemented"
      stop

--- a/src/main.f90
+++ b/src/main.f90
@@ -103,8 +103,14 @@ program kerner_code
         select case(lowtrim(parameters%mesh_file_type))
         case('tetrahedral') 
             nvertices_per_elem = 4
-            nbasisfuncs_per_elem = 4
-        case('abaqus') 
+            select case(lowtrim(parameters%int_type))
+            case('volumetric')
+                nbasisfuncs_per_elem = 1
+            case('onvertices')
+                nbasisfuncs_per_elem = 4
+            end select
+
+            case('abaqus')
             call inv_mesh%read_abaqus_meshtype(parameters%mesh_file,parameters%int_type)
             nbasisfuncs_per_elem = inv_mesh%nbasisfuncs_per_elem
             nvertices_per_elem = inv_mesh%nvertices_per_elem

--- a/src/master_queue.f90
+++ b/src/master_queue.f90
@@ -281,7 +281,8 @@ subroutine extract_receive_buffer(itask, irank)
       select case(trim(parameters%int_type))
       case('onvertices')         
         ipoint = connectivity(ibasisfunc, ielement)
-        valence = 1.d0/real(inv_mesh%nbasisfuncs_per_elem, kind=dp)
+        !valence = 1.d0/real(inv_mesh%nbasisfuncs_per_elem, kind=dp)
+        valence = 1.d0 !Changed by Harriet 9/05/18
       case('volumetric')
         ipoint = ielement
         valence = 1.d0


### PR DESCRIPTION
For volumetric integration: changing nbasis_funcs_per_elem (which later controls weighting). Weighting should be turned off in the volumetric case.
Changing sign of lambda and mu kernels: With a minus sign the derivation is consistent with Tarje's papers (and others) but not with the Fichtner book. The Fichtner book uses a different definition of misfit which I think accounts for the sign difference. The changed sign makes results of waveform modelling using the waveform kernels consistent with axisem solutions for the same model.
Changing valence to 1 for onvertices integration: This might have already been changed in the master version.